### PR TITLE
Added -fail-on-error for exit code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,8 +24,7 @@ echo "::endgroup::"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-./vendor/bin/phpstan --version
-./vendor/bin/phpstan analyse --no-progress --no-interaction --error-format=checkstyle | reviewdog -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
-
-./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version
-./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
+./vendor/bin/phpstan --version && \
+./vendor/bin/phpstan analyse --no-progress --no-interaction --error-format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version && \
+./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
I was running a test PR https://github.com/gitglacier/peak-web/pull/241 and GitHub Actions showed successful. That's because reviewdog is not passing the failing exit code. There's an option to give a non-zero exit code if reviewdog finds any errors.

Also, I did command chaining so that all four phpstan/phpstan/php-cs-fixer/php-cs-fixer commands must be non-zero, the first one will exit out of the program. (Because only the last command/last exit code will matter.)

https://github.com/reviewdog/reviewdog/blob/master/README.md#exit-codes