### PR TITLE
Parallel-lint, then phpstan, then php-cs-fixer

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,15 +24,6 @@ echo "::endgroup::"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-## Lint must pass, or else die
-#./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
-#( \
-#./vendor/bin/phpstan --version ; \
-#./vendor/bin/phpstan analyse --configuration=phpstan-ci.neon --no-progress --no-interaction --error-format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" ; \
-#./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version ; \
-#./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" ; \
-#)
-
 ./vendor/bin/parallel-lint --version && \
 ./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/bin/phpstan --version && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,18 @@ echo "::endgroup::"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+## Lint must pass, or else die
+#./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+#( \
+#./vendor/bin/phpstan --version ; \
+#./vendor/bin/phpstan analyse --configuration=phpstan-ci.neon --no-progress --no-interaction --error-format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" ; \
+#./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version ; \
+#./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" ; \
+#)
+
+./vendor/bin/parallel-lint --version && \
+./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/bin/phpstan --version && \
-./vendor/bin/phpstan analyse --no-progress --no-interaction --error-format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+./vendor/bin/phpstan analyse --configuration=phpstan-ci.neon --no-progress --no-interaction --error-format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version && \
-./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
+./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,8 +34,8 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 #)
 
 ./vendor/bin/parallel-lint --version && \
-./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/bin/phpstan --version && \
 ./vendor/bin/phpstan analyse --configuration=phpstan-ci.neon --no-progress --no-interaction --error-format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version && \
-./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \


### PR DESCRIPTION
By putting parallel-lint first, any syntax errors will be caught.