### PR TITLE
Updating reviewdog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y git unzip wget
 
-ENV REVIEWDOG_VERSION=v0.9.17
+ENV REVIEWDOG_VERSION=v0.10.0
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,8 +25,8 @@ echo "::endgroup::"
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 ./vendor/bin/parallel-lint --version && \
-./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -name="parallel-lint" -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+./vendor/bin/parallel-lint --checkstyle --exclude vendor . | reviewdog -name="parallel-lint" -filter-mode=file -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/bin/phpstan --version && \
-./vendor/bin/phpstan analyse --no-progress --no-interaction --error-format=checkstyle | reviewdog -name="phpstan" -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
+./vendor/bin/phpstan analyse --no-progress --no-interaction --error-format=checkstyle | reviewdog -name="phpstan" -filter-mode=file -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" && \
 ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer --version && \
-./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -name="php-cs-fixer" -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
+./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --dry-run --format=checkstyle | reviewdog -name="php-cs-fixer" -filter-mode=file -fail-on-error -f=checkstyle -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
`-fail-on-error` previously didn't work because I was on an older review of reviewdog. I just pushed the version number.